### PR TITLE
Update codegrade_mvp.test.js

### DIFF
--- a/codegrade_mvp.test.js
+++ b/codegrade_mvp.test.js
@@ -226,7 +226,7 @@ describe("getArtistByIndex", () => {
 });
 
 describe("listOfNames", () => {
-  it("listOfNames returns an array. Review how to loop over data, use array methods, accessing data in an array, and accessing data on an object.", () => {
+  it("listOfNames returns an array. Review how to loop over data, accessing data in an array, and accessing data on an object.", () => {
     expect(functions.listOfNames(artists)).toEqual([
       "Amedeo Modigliani",
       "Vasiliy Kandinskiy",
@@ -253,7 +253,7 @@ describe("listOfNames", () => {
 });
 
 describe("removeArtist", () => {
-  it("removeArtist returns an array. Review array methods such as filter or map, and how to access properties on an object", () => {
+  it("removeArtist returns an array. Review how to access properties on an object", () => {
     expect(functions.removeArtist(artists, 0)).toStrictEqual([
       {
         id: 1,
@@ -664,7 +664,7 @@ describe("addArtist", () => {
 });
 
 describe("lotsOfArt", () => {
-  it("lotsOfArt returns an array. Review array methods like filter and how to access properties on an object", () => {
+  it("lotsOfArt returns an array. Review how to access properties on an object", () => {
     expect(functions.lotsOfArt(artists)).toEqual([
       "Amedeo Modigliani",
       "Rene Magritte",
@@ -685,7 +685,7 @@ describe("lotsOfArt", () => {
 });
 
 describe("artistInfo", () => {
-  it("artistInfo returns a bio. Review array methods like map and how to access properties on an object", () => {
+  it("artistInfo returns a bio. Review how to access properties on an object", () => {
     expect(functions.artistInfo(artists, "Kazimir Malevich")).toEqual(
       `Kazimir Severinovich Malevich (February 23 [O.S. 11] 1879 – May 15, 1935) was a Russian avant-garde artist and art theorist, whose pioneering work and writing had a profound influence on the development of non-objective, or abstract art, in the 20th century. Born in Kiev to an ethnic Polish family, his concept of Suprematism sought to develop a form of expression that moved as far as possible from the world of natural forms (objectivity) and subject matter in order to access "the supremacy of pure feeling" and spirituality.Early on, Malevich worked in a variety of styles, quickly assimilating the movements of Impressionism, Symbolism and Fauvism, and after visiting Paris in 1912, Cubism. Gradually simplifying his style, he developed an approach with key works consisting of pure geometric forms and their relationships to one another, set against minimal grounds. His Black Square (1915), a black square on white, represented the most radically abstract painting known to have been created so far and drew "an uncrossable line (…) between old art and new art"; Suprematist Composition: White on White (1918), a barely differentiated off-white square superimposed on an off-white ground, would take his ideal of pure abstraction to its logical conclusion. In addition to his paintings, Malevich laid down his theories in writing, such as "From Cubism and Futurism to Suprematism" (1915) and The Non-Objective World: The Manifesto of Suprematism (1926).Malevich's trajectory in many ways mirrored the tumult of the decades surrounding the October Revolution (O.S.) in 1917. In its immediate aftermath, vanguard movements such as Suprematism and Vladimir Tatlin's Constructivism were encouraged by Trotskyite factions in the government. Malevich held several prominent teaching positions and received a solo show at the Sixteenth State Exhibition in Moscow in 1919. His recognition spread to the West with solo exhibitions in Warsaw and Berlin in 1927. Upon his return, modern art was falling out of favor with the new government of Joseph Stalin. Malevich soon lost his teaching position, artworks and manuscripts were confiscated, and he was banned from making art. In 1930, he was imprisoned for two months due to suspicions raised by his trip to Poland and Germany. Forced to abandon abstraction, he painted in a representational style in the years before his death from cancer in 1935, at the age of 56.`,
     );
@@ -693,7 +693,7 @@ describe("artistInfo", () => {
 });
 
 describe("artistByCountry", () => {
-  it("artistByCountry returns an array. Review array methods like map and how to access properties on an object", () => {
+  it("artistByCountry returns an array. Review how to access properties on an object", () => {
     expect(functions.artistByCountry(artists, "Spanish")).toEqual([
       "Salvador Dali",
       "Pablo Picasso",
@@ -703,7 +703,7 @@ describe("artistByCountry", () => {
 });
 
 describe("artistByCountry", () => {
-  it("artistByCountry returns an array. Review array methods like map and how to access properties on an object", () => {
+  it("artistByCountry returns an array. Review how to access properties on an object", () => {
     expect(functions.artistByCountry(artists, "Russian")).toEqual([
       "Vasiliy Kandinskiy",
       "Andrei Rublev",


### PR DESCRIPTION
Removed all references to array methods because it is not covered in the first Sprint and Learners do not know what they are.